### PR TITLE
[FIX] Fixed position for Menu icon

### DIFF
--- a/CSS/index.css
+++ b/CSS/index.css
@@ -245,7 +245,7 @@ input[type=checkbox] {
     }
 
     .hamburger {
-        position: absolute;
+        position: fixed;
         right: 5px;
         z-index: 10;
         margin-top: 15px;

--- a/CSS/teams.css
+++ b/CSS/teams.css
@@ -209,7 +209,7 @@ input[type=checkbox]{
         
     }
     .hamburger {
-        position: absolute;
+        position: fixed;
         right: 5px;
         z-index: 10;
         margin-top: 15px;


### PR DESCRIPTION
On opening the menu overlay on mobile devices, the menu icon was previously being scrolled away. Now fixed.